### PR TITLE
Also replicates message key

### DIFF
--- a/lib/kafka_replicator/topics_replicator.rb
+++ b/lib/kafka_replicator/topics_replicator.rb
@@ -94,7 +94,8 @@ module KafkaReplicator
             destination_producer.produce(
               mark_as_replica(message.value),
               topic: message.topic,
-              partition: message.partition
+              partition: message.partition,
+              key: message.key
             )
 
             source_consumer.mark_message_as_processed(message)


### PR DESCRIPTION
In cw-mailer we also use message `key`, [for example](https://github.com/catawiki/cw-mailer/blob/7f6ae25e8148e78618d82d9df85b3eed2af195b9/lib/consumer/batch.rb#L22), to consume only the last message in a group.